### PR TITLE
implement fix for the Issue #52

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -17,7 +17,7 @@
 #ifndef CONFIG_H
 # define CONFIG_H
 
-# define SOFTWARE_VERSION       4.39
+# define SOFTWARE_VERSION       4.38
 # define DEVICE_NAME            "42PRAGUEAPI SCREEN"
 
 # define DEBUG                                               // comment out this line to turn off Serial output
@@ -38,7 +38,7 @@
                                                                 // Make sure to use only the Winter-time time zone; 
                                                                 // Include "-" sign if applies. Do not include "+" sign.
 /* Time limits */
-# define CONNECT_TIMEOUT_S      5                            // wi-fi
+# define CONNECT_TIMEOUT_S      10                           // wi-fi
 # define DEBOUNCE_DELAY_MS      1000ul                       // buttons
 # define WD_TIMEOUT_MS          8000                         // watchdog
 # define SERVER_WAIT_MS         1000                         // Intra

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -93,8 +93,14 @@ void  ft_delay(uint64_t time_in_millis)
 */
 bool ensure_wifi_connection(void)
 {
+    uint32_t  start_ms;
+
     if (WiFi.status() == WL_CONNECTED)
         return (true);
+    WiFi.mode(WIFI_OFF);
+    start_ms = millis();
+    while (WiFi.getMode() != WIFI_OFF && (millis() - start_ms) < 200)
+        delay(10);
     wifi_connect();
     watchdog_reset();
     if (WiFi.status() != WL_CONNECTED)


### PR DESCRIPTION
Fix for the Issue #52. The issue was resolved by forcing the WiFi module to restart, effectively cleaning the WiFi stack. Now, once the WiFi Access Point is available, the device is able to successfully connect to it despite previous fails.